### PR TITLE
Allow log directory to be customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ bin/
 .terraform
 .terraform.lock.hcl
 *.tfstate*
+my-*
+oci-sd
+oci-sd.log
+

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can run `oci-sd --help` to see command line configuration flags:
     Usage of ./bin/oci-sd:
       -t, --compartment string   compartment for discovering targets
       -c, --config-file string   external config file (default "oci-sd.toml")
+      -l, --log-directory string log file location (default "/var/log/oci-sd/")
       -i, --instance-principal   initialise with instance principal authentication
       -o, --output-file string   output file for file_sd compatible file (default "oci-sd.json")
       -s, --sanitise             sanitise instance tags to fit Prometheus requirements by removing special characters (:, -)
@@ -157,7 +158,7 @@ The following meta-labels are available on targets during re-labeling:
 
 ## Logs
 
-The default log location is `/var/log/oci-sd/oci-sd.log`. It can be changed by editing the LOG_PATH variable.
+The default log location is `/var/log/oci-sd/oci-sd.log`. It can be changed by passing in a custom --log-directory variable.
 
 ## Example
 

--- a/main.go
+++ b/main.go
@@ -39,28 +39,29 @@ import (
 )
 
 var (
-	configFile  string
-	outputFile  string
-	authvar     bool
-	cfg         config
-	compartment string
-	sanitise    bool
+	configFile   string
+	outputFile   string
+	logDirectory string
+	authvar      bool
+	cfg          config
+	compartment  string
+	sanitise     bool
 )
 
 func init() {
 	flag.StringVarP(&configFile, "config-file", "c", "oci-sd.toml", "external config file")
 	flag.StringVarP(&outputFile, "output-file", "o", "oci-sd.json", "output file for file_sd compatible file")
+	flag.StringVarP(&logDirectory, "log-directory", "l", "/var/log/oci-sd/", "log directory")
 	flag.BoolVarP(&authvar, "instance-principal", "i", false, "initialise with instance principal authentication")
 	flag.StringVarP(&compartment, "compartment", "t", "", "compartment for discovering targets")
 	flag.BoolVarP(&sanitise, "sanitise", "s", false, "sanitise instance tags to fit Prometheus requirements by removing special characters (:, -)")
 }
 
-const LOG_PATH = "/var/log/oci-sd/"
-
 func main() {
 	flag.Parse()
 	logger := log.New()
-	logSetup(LOG_PATH, logger)
+
+	logSetup(logDirectory, logger)
 
 	if authvar {
 		logger.Info("initialising with instance principal authentication")


### PR DESCRIPTION
The log directory is hardcoded as /var/log/oci-sd/.  When running locally on a mac as a non-root user that directory is restricted requiring the developer to sudo to run.  It would be nice, particularly for development reasons, to allow the log directory to be customized from the command line just like the output directory.

I've updated the code to allow a -l or --log-directory command line arg to be passed in.  If it is not passed in, the default (/var/log/oci-sd) is maintained.  This makes this change backward compatible.
